### PR TITLE
Implementación de los endpoints de métricas de ventas y compras en el…

### DIFF
--- a/apps/purchases/serializers/purchases.py
+++ b/apps/purchases/serializers/purchases.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 # Django REST Framework
 from rest_framework import serializers
 
@@ -48,6 +50,7 @@ class UpdateAndCreatePurchasesDetailsModelSerializer(serializers.ModelSerializer
 class UpdateAndCreatePurchasesSerializer(serializers.ModelSerializer):
     purchase_details = UpdateAndCreatePurchasesDetailsModelSerializer(many=True, required=True)
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())
+    purchase_date = serializers.DateField(default=date.today)
    
     class Meta:
         """Meta class."""

--- a/apps/reports/urls.py
+++ b/apps/reports/urls.py
@@ -10,7 +10,8 @@ from rest_framework.routers import DefaultRouter
 from apps.reports import views
 
 router = DefaultRouter()
-router.register(r'reports/sales', views.SalesReportsViewset, basename='reports')
+router.register(r'reports/sales', views.SalesReportsViewset, basename='reports_sales')
+router.register(r'reports/dashboard', views.DashboardReportsViewset, basename='reports_dashboard')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/apps/reports/views/__init__.py
+++ b/apps/reports/views/__init__.py
@@ -1,1 +1,2 @@
 from .sales import SalesReportsViewset
+from .dashboard import DashboardReportsViewset

--- a/apps/reports/views/dashboard.py
+++ b/apps/reports/views/dashboard.py
@@ -1,0 +1,89 @@
+# Django
+from django.http import JsonResponse
+from django.db.models import Sum
+from django.utils.timezone import now
+from datetime import datetime
+
+# Django Rest Framework
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.decorators import action
+from rest_framework.viewsets import GenericViewSet
+from rest_framework.serializers import ValidationError
+
+# Swagger
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
+# Models
+from apps.sales.models.sales import Sales
+from apps.purchases.models.purchases import Purchases
+from apps.sales.models.customers import Customers
+
+
+class DashboardReportsViewset(GenericViewSet):
+    permission_classes = [IsAuthenticated]
+
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                'filter_date',
+                openapi.IN_QUERY,
+                description="Fecha actual en formato YYYY-MM-DD",
+                type=openapi.TYPE_STRING,
+                required=False
+            )
+        ],
+        responses={
+            status.HTTP_200_OK: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    'ventas': openapi.Schema(type=openapi.TYPE_INTEGER),
+                    'total_ventas': openapi.Schema(type=openapi.TYPE_NUMBER),
+                    'compras': openapi.Schema(type=openapi.TYPE_INTEGER),
+                    'total_compras': openapi.Schema(type=openapi.TYPE_NUMBER),
+                    'utilidad': openapi.Schema(type=openapi.TYPE_NUMBER),
+                    'clientes_nuevos_del_mes': openapi.Schema(type=openapi.TYPE_INTEGER),
+                    'todos_los_clientes': openapi.Schema(type=openapi.TYPE_INTEGER),
+                }
+            )
+        }
+    )
+    @action(detail=False, methods=["GET"])
+    def metrics(self, request, *args, **kwargs):
+        # Obtener parámetro de fecha actual
+        filter_date = request.query_params.get("filter_date")
+        if filter_date:
+            try:
+                fecha = datetime.strptime(filter_date, "%Y-%m-%d")
+            except ValueError:
+                raise ValidationError({'detail': ["Formato de fecha inválido. Use YYYY-MM-DD"]})
+        else:
+            fecha = now()
+
+        mes_actual = fecha.month
+        anno_actual = fecha.year
+
+        # Cálculos
+        ventas_mes = Sales.objects.filter(sale_date__year=anno_actual, sale_date__month=mes_actual, is_active=True)
+        total_ventas = ventas_mes.aggregate(total=Sum("total"))["total"] or 0
+
+        compras_mes = Purchases.objects.filter(purchase_date__year=anno_actual, purchase_date__month=mes_actual, is_active=True)
+        total_compras = compras_mes.aggregate(total=Sum("total"))["total"] or 0
+
+        clientes_nuevos = Customers.objects.filter(created__year=anno_actual, created__month=mes_actual, is_active=True).count()
+        total_clientes = Customers.objects.filter(is_active=True).count()
+
+        utilidad = total_ventas - total_compras
+
+        # Respuesta
+        data = {
+            "ventas": ventas_mes.count(),
+            "total_ventas": total_ventas,
+            "compras": compras_mes.count(),
+            "total_compras": total_compras,
+            "utilidad": utilidad,
+            "clientes_nuevos": clientes_nuevos,
+            "todos_los_clientes": total_clientes,
+        }
+        return JsonResponse(data, status=status.HTTP_200_OK)

--- a/apps/reports/views/sales.py
+++ b/apps/reports/views/sales.py
@@ -1,6 +1,8 @@
 # Django
-from django.http import HttpResponse
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
+from django.db.models import F, Sum, Count
+from django.utils.timezone import now
+from datetime import datetime
 
 # Django Rest Framework
 from rest_framework import status
@@ -9,29 +11,27 @@ from rest_framework.decorators import action
 from rest_framework.viewsets import GenericViewSet
 from rest_framework.serializers import ValidationError
 
-# Django models
-from django.db.models import F
-
 # Utils
-import io
-import pandas as pd
 from django_pandas.io import read_frame
+from apps.utils.logic.reports import df_to_excel, format_currency
 
 # Swagger
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 
 # Models
-from apps.reports.constant import ReportResponseFormatChoices
+from apps.sales.models.sales import Sales
+from apps.purchases.models.purchases import Purchases
+from apps.sales.models.customers import Customers
+
+# Filters y Serializers
 from apps.reports.filters import SalesReportFilter
 from apps.reports.serializers.sales import SalesReportSerializer
-from apps.sales.models.sales import Sales
-from apps.utils.logic.reports import df_to_excel, format_currency
 from apps.utils.serializers.globals import WithChoicesSerializer
+from apps.reports.constant import ReportResponseFormatChoices
 
 
 class SalesReportsViewset(GenericViewSet):
-
     permission_classes = [IsAuthenticated]
 
     @swagger_auto_schema(
@@ -45,27 +45,24 @@ class SalesReportsViewset(GenericViewSet):
     )
     @action(detail=False, methods=["GET"])
     def general(self, request, *args, **kwargs):
-
         serializer = SalesReportSerializer(
             data=request.GET,
         )
         serializer.is_valid(raise_exception=True)
         serializer_data = serializer.data
-        
-        queryset = Sales.objects\
-            .filter(is_active=True)\
-            .annotate(
-                fecha=F('sale_date'), 
-                metodo_pago=WithChoicesSerializer(Sales, 'payment_method'),
-                estado=F('sale_status__name'),
-                cliente=F('customer__name'),
-                categoria=F('salesdetails__product__category__name'), 
-                producto=F('salesdetails__product__name'),
-                cantidad=F('salesdetails__quantity'),
-                precio_unitario=F('salesdetails__unit_value'),
-                subtotal=F('salesdetails__subtotal'),
-                total_venta=F('total'),
-            )
+
+        queryset = Sales.objects.filter(is_active=True).annotate(
+            fecha=F('sale_date'),
+            metodo_pago=WithChoicesSerializer(Sales, 'payment_method'),
+            estado=F('sale_status__name'),
+            cliente=F('customer__name'),
+            categoria=F('salesdetails__product__category__name'),
+            producto=F('salesdetails__product__name'),
+            cantidad=F('salesdetails__quantity'),
+            precio_unitario=F('salesdetails__unit_value'),
+            subtotal=F('salesdetails__subtotal'),
+            total_venta=F('total'),
+        )
 
         report_filter = SalesReportFilter(serializer_data, queryset=queryset)
         queryset = report_filter.qs.order_by('id')
@@ -75,7 +72,7 @@ class SalesReportsViewset(GenericViewSet):
 
         reporte = read_frame(queryset)
 
-         # Formato moneda
+        # Formato moneda
         reporte['precio_unitario'] = reporte['precio_unitario'].apply(format_currency)
         reporte['subtotal'] = reporte['subtotal'].apply(format_currency)
         reporte['total_venta'] = reporte['total_venta'].apply(format_currency)
@@ -83,7 +80,7 @@ class SalesReportsViewset(GenericViewSet):
         # Establecer todas las filas de 'total_venta' a NaN excepto la primera fila de cada venta (mismo 'id')
         reporte['total_venta'] = reporte['total_venta'].mask(reporte.duplicated(subset=['id']))
 
-        order_columns = ['id', 'cliente', 'fecha', 'estado', 'metodo_pago', 'categoria', 
+        order_columns = ['id', 'cliente', 'fecha', 'estado', 'metodo_pago', 'categoria',
                          'producto', 'cantidad', 'precio_unitario', 'subtotal', 'total_venta']
         reporte = reporte[order_columns]
 
@@ -92,7 +89,71 @@ class SalesReportsViewset(GenericViewSet):
             response = HttpResponse(workbook, content_type="application/ms-excel")
             response['Content-Disposition'] = 'attachment; filename=reporte_general_de_ventas.xlsx'
             return response
-        
+
         reporte = reporte.fillna('')
         json_data = reporte.to_dict(orient='records')
         return JsonResponse(json_data, safe=False)
+
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                'fecha_actual',
+                openapi.IN_QUERY,
+                description="Fecha actual en formato YYYY-MM-DD",
+                type=openapi.TYPE_STRING,
+                required=False
+            )
+        ],
+        responses={
+            status.HTTP_200_OK: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    'ventas': openapi.Schema(type=openapi.TYPE_INTEGER),
+                    'total_ventas': openapi.Schema(type=openapi.TYPE_NUMBER),
+                    'compras': openapi.Schema(type=openapi.TYPE_INTEGER),
+                    'total_compras': openapi.Schema(type=openapi.TYPE_NUMBER),
+                    'utilidad': openapi.Schema(type=openapi.TYPE_NUMBER),
+                    'clientes_nuevos_del_mes': openapi.Schema(type=openapi.TYPE_INTEGER),
+                    'todos_los_clientes': openapi.Schema(type=openapi.TYPE_INTEGER),
+                }
+            )
+        }
+    )
+    @action(detail=False, methods=["GET"])
+    def dashboard_metrics(self, request, *args, **kwargs):
+        # Obtener parámetro de fecha actual
+        fecha_actual = request.query_params.get("fecha_actual")
+        if fecha_actual:
+            try:
+                fecha = datetime.strptime(fecha_actual, "%Y-%m-%d")
+            except ValueError:
+                raise ValidationError({'detail': ["Formato de fecha inválido. Use YYYY-MM-DD"]})
+        else:
+            fecha = now()
+
+        mes_actual = fecha.month
+        año_actual = fecha.year
+
+        # Cálculos
+        ventas_mes = Sales.objects.filter(created__year=año_actual, created__month=mes_actual, is_active=True)
+        total_ventas = ventas_mes.aggregate(total=Sum("total"))["total"] or 0
+
+        compras_mes = Purchases.objects.filter(purchase_date__year=año_actual, purchase_date__month=mes_actual, is_active=True)
+        total_compras = compras_mes.aggregate(total=Sum("total"))["total"] or 0
+
+        clientes_nuevos = Customers.objects.filter(created__year=año_actual, created__month=mes_actual).count()
+        total_clientes = Customers.objects.count()
+
+        utilidad = total_ventas - total_compras
+
+        # Respuesta
+        data = {
+            "ventas": ventas_mes.count(),
+            "total_ventas": total_ventas,
+            "compras": compras_mes.count(),
+            "total_compras": total_compras,
+            "utilidad": utilidad,
+            "clientes_nuevos_del_mes": clientes_nuevos,
+            "todos_los_clientes": total_clientes,
+        }
+        return JsonResponse(data, status=status.HTTP_200_OK)

--- a/apps/reports/views/sales.py
+++ b/apps/reports/views/sales.py
@@ -1,8 +1,6 @@
 # Django
 from django.http import HttpResponse, JsonResponse
-from django.db.models import F, Sum, Count
-from django.utils.timezone import now
-from datetime import datetime
+from django.db.models import F
 
 # Django Rest Framework
 from rest_framework import status
@@ -21,8 +19,6 @@ from drf_yasg import openapi
 
 # Models
 from apps.sales.models.sales import Sales
-from apps.purchases.models.purchases import Purchases
-from apps.sales.models.customers import Customers
 
 # Filters y Serializers
 from apps.reports.filters import SalesReportFilter
@@ -93,67 +89,3 @@ class SalesReportsViewset(GenericViewSet):
         reporte = reporte.fillna('')
         json_data = reporte.to_dict(orient='records')
         return JsonResponse(json_data, safe=False)
-
-    @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
-                'fecha_actual',
-                openapi.IN_QUERY,
-                description="Fecha actual en formato YYYY-MM-DD",
-                type=openapi.TYPE_STRING,
-                required=False
-            )
-        ],
-        responses={
-            status.HTTP_200_OK: openapi.Schema(
-                type=openapi.TYPE_OBJECT,
-                properties={
-                    'ventas': openapi.Schema(type=openapi.TYPE_INTEGER),
-                    'total_ventas': openapi.Schema(type=openapi.TYPE_NUMBER),
-                    'compras': openapi.Schema(type=openapi.TYPE_INTEGER),
-                    'total_compras': openapi.Schema(type=openapi.TYPE_NUMBER),
-                    'utilidad': openapi.Schema(type=openapi.TYPE_NUMBER),
-                    'clientes_nuevos_del_mes': openapi.Schema(type=openapi.TYPE_INTEGER),
-                    'todos_los_clientes': openapi.Schema(type=openapi.TYPE_INTEGER),
-                }
-            )
-        }
-    )
-    @action(detail=False, methods=["GET"])
-    def dashboard_metrics(self, request, *args, **kwargs):
-        # Obtener parámetro de fecha actual
-        fecha_actual = request.query_params.get("fecha_actual")
-        if fecha_actual:
-            try:
-                fecha = datetime.strptime(fecha_actual, "%Y-%m-%d")
-            except ValueError:
-                raise ValidationError({'detail': ["Formato de fecha inválido. Use YYYY-MM-DD"]})
-        else:
-            fecha = now()
-
-        mes_actual = fecha.month
-        año_actual = fecha.year
-
-        # Cálculos
-        ventas_mes = Sales.objects.filter(created__year=año_actual, created__month=mes_actual, is_active=True)
-        total_ventas = ventas_mes.aggregate(total=Sum("total"))["total"] or 0
-
-        compras_mes = Purchases.objects.filter(purchase_date__year=año_actual, purchase_date__month=mes_actual, is_active=True)
-        total_compras = compras_mes.aggregate(total=Sum("total"))["total"] or 0
-
-        clientes_nuevos = Customers.objects.filter(created__year=año_actual, created__month=mes_actual).count()
-        total_clientes = Customers.objects.count()
-
-        utilidad = total_ventas - total_compras
-
-        # Respuesta
-        data = {
-            "ventas": ventas_mes.count(),
-            "total_ventas": total_ventas,
-            "compras": compras_mes.count(),
-            "total_compras": total_compras,
-            "utilidad": utilidad,
-            "clientes_nuevos_del_mes": clientes_nuevos,
-            "todos_los_clientes": total_clientes,
-        }
-        return JsonResponse(data, status=status.HTTP_200_OK)

--- a/apps/sales/serializers/sales.py
+++ b/apps/sales/serializers/sales.py
@@ -38,8 +38,6 @@ class UpdateAndCreateSalesDetailsSerializer(serializers.ModelSerializer):
         exclude = ('sale',)
 
 
-
-
 class UpdateAndCreateSalesSerializer(serializers.ModelSerializer):
     sale_details = UpdateAndCreateSalesDetailsSerializer(many=True, required=True)
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())

--- a/fixtures/customers.json
+++ b/fixtures/customers.json
@@ -3,85 +3,85 @@
         "model": "sales.customers",
         "pk": 1,
         "fields": {
-            "name": "MARIA CONGALEZ",
+            "name": "MARIO PÉREZ",
             "identification_type": "CC",
             "identification_number": "9876543210",
             "cell_phone": "3007654321",
-            "email": "maria.gonzalez@example.com",
+            "email": "mario.perez@example.com",
             "birth_date": "1985-03-15",
             "residential_address": "456 Avenida Principal",
             "city": 2,
             "is_active": true,
-            "created": "2024-10-02T11:30:00Z",
-            "updated": "2024-10-02T11:30:00Z"
+            "created": "2024-11-01T11:30:00Z",
+            "updated": "2024-11-01T11:30:00Z"
         }
     },
     {
         "model": "sales.customers",
         "pk": 2,
         "fields": {
-            "name": "CARLOS MARTINEZ",
+            "name": "LUISA FERNÁNDEZ",
             "identification_type": "TI",
             "identification_number": "1357924680",
             "cell_phone": "3101239876",
-            "email": "carlos.martinez@example.com",
-            "birth_date": "2000-07-25",
+            "email": "luisa.fernandez@example.com",
+            "birth_date": "1990-09-20",
             "residential_address": "789 Calle Secundaria",
             "city": 3,
             "is_active": true,
-            "created": "2024-10-03T14:20:00Z",
-            "updated": "2024-10-03T14:20:00Z"
+            "created": "2024-11-02T14:20:00Z",
+            "updated": "2024-11-02T14:20:00Z"
         }
     },
     {
         "model": "sales.customers",
         "pk": 3,
         "fields": {
-            "name": "ANA LOPEZ",
+            "name": "JOSE LÓPEZ",
             "identification_type": "CE",
             "identification_number": "1029384756",
             "cell_phone": "3156781234",
-            "email": "ana.lopez@example.com",
-            "birth_date": "1995-11-05",
+            "email": "jose.lopez@example.com",
+            "birth_date": "1985-04-12",
             "residential_address": "321 Calle Central",
             "city": 4,
             "is_active": false,
-            "created": "2024-10-04T16:45:00Z",
-            "updated": "2024-10-04T16:45:00Z"
+            "created": "2024-11-03T16:45:00Z",
+            "updated": "2024-11-03T16:45:00Z"
         }
     },
     {
         "model": "sales.customers",
         "pk": 4,
         "fields": {
-            "name": "LUIS ROFRIGUEZ",
+            "name": "CAMILA RAMIREZ",
             "identification_type": "CC",
             "identification_number": "5647382910",
             "cell_phone": "3182345678",
-            "email": "luis.rodriguez@example.com",
-            "birth_date": "1988-02-18",
+            "email": "camila.ramirez@example.com",
+            "birth_date": "1992-08-25",
             "residential_address": "654 Calle Tercera",
             "city": 5,
             "is_active": true,
-            "created": "2024-10-05T09:15:00Z",
-            "updated": "2024-10-05T09:15:00Z"
+            "created": "2024-11-04T09:15:00Z",
+            "updated": "2024-11-04T09:15:00Z"
         }
     },
     {
         "model": "sales.customers",
         "pk": 5,
         "fields": {
-            "name": "PATRICIA SANCHEZ",
+            "name": "ANDREA GUTIÉRREZ",
             "identification_type": "CC",
             "identification_number": "6789012345",
             "cell_phone": "3225678901",
-            "email": "patricia.sanchez@example.com",
-            "birth_date": "1993-12-22",
+            "email": "andrea.gutierrez@example.com",
+            "birth_date": "1990-06-14",
             "residential_address": "987 Calle Cuarta",
             "city": 6,
             "is_active": true,
-            "created": "2024-10-06T13:50:00Z",
-            "updated": "2024-10-06T13:50:00Z"
+            "created": "2024-11-05T13:50:00Z",
+            "updated": "2024-11-05T13:50:00Z"
         }
     }
 ]

--- a/fixtures/sales.json
+++ b/fixtures/sales.json
@@ -8,8 +8,60 @@
             "payment_method": "1",
             "sale_status": 1,
             "total": "200.00",
-            "created": "2024-10-01T10:00:00Z",
-            "updated": "2024-10-01T10:00:00Z"
+            "created": "2024-11-01T10:00:00Z",
+            "updated": "2024-11-01T10:00:00Z"
+        }
+    },
+    {
+        "model": "sales.sales",
+        "pk": 2,
+        "fields": {
+            "customer": 2,
+            "user": 1,
+            "payment_method": "2",
+            "sale_status": 2,
+            "total": "350.00",
+            "created": "2024-11-05T12:30:00Z",
+            "updated": "2024-11-05T12:30:00Z"
+        }
+    },
+    {
+        "model": "sales.sales",
+        "pk": 3,
+        "fields": {
+            "customer": 3,
+            "user": 1,
+            "payment_method": "3",
+            "sale_status": 3,
+            "total": "500.00",
+            "created": "2024-11-10T15:00:00Z",
+            "updated": "2024-11-10T15:00:00Z"
+        }
+    },
+    {
+        "model": "sales.sales",
+        "pk": 4,
+        "fields": {
+            "customer": 4,
+            "user": 1,
+            "payment_method": "1",
+            "sale_status": 1,
+            "total": "150.00",
+            "created": "2024-11-12T11:00:00Z",
+            "updated": "2024-11-12T11:00:00Z"
+        }
+    },
+    {
+        "model": "sales.sales",
+        "pk": 5,
+        "fields": {
+            "customer": 5,
+            "user": 1,
+            "payment_method": "2",
+            "sale_status": 2,
+            "total": "450.00",
+            "created": "2024-11-15T14:45:00Z",
+            "updated": "2024-11-15T14:45:00Z"
         }
     }
 ]

--- a/fixtures/sales_details.json
+++ b/fixtures/sales_details.json
@@ -8,8 +8,60 @@
             "quantity": 2,
             "unit_value": "100.00",
             "subtotal": "200.00",
-            "created": "2024-10-01T10:00:00Z",
-            "updated": "2024-10-01T10:00:00Z"
+            "created": "2024-11-01T10:00:00Z",
+            "updated": "2024-11-01T10:00:00Z"
+        }
+    },
+    {
+        "model": "sales.salesdetails",
+        "pk": 2,
+        "fields": {
+            "sale": 2,
+            "product": 2,
+            "quantity": 3,
+            "unit_value": "100.00",
+            "subtotal": "300.00",
+            "created": "2024-11-05T12:30:00Z",
+            "updated": "2024-11-05T12:30:00Z"
+        }
+    },
+    {
+        "model": "sales.salesdetails",
+        "pk": 3,
+        "fields": {
+            "sale": 3,
+            "product": 3,
+            "quantity": 5,
+            "unit_value": "100.00",
+            "subtotal": "500.00",
+            "created": "2024-11-10T15:00:00Z",
+            "updated": "2024-11-10T15:00:00Z"
+        }
+    },
+    {
+        "model": "sales.salesdetails",
+        "pk": 4,
+        "fields": {
+            "sale": 4,
+            "product": 1,
+            "quantity": 1,
+            "unit_value": "150.00",
+            "subtotal": "150.00",
+            "created": "2024-11-12T11:00:00Z",
+            "updated": "2024-11-12T11:00:00Z"
+        }
+    },
+    {
+        "model": "sales.salesdetails",
+        "pk": 5,
+        "fields": {
+            "sale": 5,
+            "product": 2,
+            "quantity": 2,
+            "unit_value": "225.00",
+            "subtotal": "450.00",
+            "created": "2024-11-15T14:45:00Z",
+            "updated": "2024-11-15T14:45:00Z"
         }
     }
 ]


### PR DESCRIPTION
Se implementaron los endpoints en el viewset `SalesReportsViewset` para proporcionar métricas sobre ventas y compras en el dashboard:

1. **Endpoint de métricas del dashboard (`/dashboard_metrics/`)**:
   - Este endpoint calcula y devuelve las métricas de ventas y compras para el mes actual, basado en la fecha proporcionada o la fecha actual si no se especifica.
   - Se agregan métricas como el total de ventas, el total de compras, la utilidad, el número de clientes nuevos y el total de clientes.
   - Se asegura que los cálculos consideren solo las ventas y compras activas para el mes solicitado.

2. **Validación y manejo de fechas**:
   - Se implementa validación para asegurar que las fechas sean correctas (en formato `YYYY-MM-DD`).
   - Si no se proporciona una fecha, se utiliza la fecha actual del sistema.

3. **Ajustes en la respuesta**:
   - Se manejan correctamente los valores nulos en los cálculos y se formatean para que siempre devuelvan números.
   - El retorno de datos es en formato JSON, con una estructura clara que incluye ventas, compras, utilidad y estadísticas de clientes.

Con estos cambios, el sistema ahora es capaz de generar métricas clave de rendimiento directamente desde la API, facilitando el acceso a estos datos para los usuarios autorizados.
